### PR TITLE
fix: CSharp was ignoring `--ignore-usings` option CY-5026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /project/project/
 /project/target/
 /target/
+/.bsp
 .idea
 .DS_Store
 .vscode

--- a/docs/duplication-tests/csharp-using/results.xml
+++ b/docs/duplication-tests/csharp-using/results.xml
@@ -1,0 +1,3 @@
+<checkstyle version="4.3">
+    <property name="ignoreMessage"></property>
+</checkstyle>

--- a/docs/duplication-tests/csharp-using/src/Test1.cs
+++ b/docs/duplication-tests/csharp-using/src/Test1.cs
@@ -1,0 +1,17 @@
+using MyLib.A.B.C;
+using MyLib.A;
+using MyLib.A.C;
+using MyLib.C.D;
+using MyLib2.A.B.C;
+using MyLib2.A;
+using MyLib2.A.C;
+using MyLib2.C.D;
+using MyLib3.A.B.C;
+using MyLib3.A;
+using MyLib3.A.C;
+using MyLib3.C.D;
+
+namespace ANameSpace
+{
+	
+}

--- a/docs/duplication-tests/csharp-using/src/Test2.cs
+++ b/docs/duplication-tests/csharp-using/src/Test2.cs
@@ -1,0 +1,17 @@
+using MyLib.A.B.C;
+using MyLib.A;
+using MyLib.A.C;
+using MyLib.C.D;
+using MyLib2.A.B.C;
+using MyLib2.A;
+using MyLib2.A.C;
+using MyLib2.C.D;
+using MyLib3.A.B.C;
+using MyLib3.A;
+using MyLib3.A.C;
+using MyLib3.C.D;
+
+namespace AnotherNamespace
+{
+	
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,20 +10,22 @@ object Dependencies {
 
   val scalaMeta = "org.scalameta" %% "scalameta" % "4.4.28"
 
-  private val pmdGroupArtifactID = "net.sourceforge.pmd"
-  private val pmdVersion = "6.38.0"
-  private val scalaPmd = pmdGroupArtifactID %% "pmd-scala" % pmdVersion
-  private val javaPmd = pmdGroupArtifactID % "pmd-java" % pmdVersion
-  private val javascriptPmd = pmdGroupArtifactID % "pmd-javascript" % pmdVersion
-  private val rubyPmd = pmdGroupArtifactID % "pmd-ruby" % pmdVersion
-  private val pythonPmd = pmdGroupArtifactID % "pmd-python" % pmdVersion
-  private val csPmd = pmdGroupArtifactID % "pmd-cs" % pmdVersion
-  private val cppPmd = pmdGroupArtifactID % "pmd-cpp" % pmdVersion
-  private val goPmd = pmdGroupArtifactID % "pmd-go" % pmdVersion
-  private val plsqlPmd = pmdGroupArtifactID % "pmd-plsql" % pmdVersion
-  private val swiftPmd = pmdGroupArtifactID % "pmd-swift" % pmdVersion
-  val pmdLanguages = Seq(csPmd, cppPmd, javascriptPmd, goPmd, javaPmd, plsqlPmd, pythonPmd, rubyPmd, scalaPmd, swiftPmd)
+  private val pmdVersion = "6.39.0"
 
+  val pmdLanguages = Seq(
+    "scala",
+    "java",
+    "javascript",
+    "ruby",
+    "python",
+    "cs",
+    "cpp",
+    "go",
+    "plsql",
+    "swift").map {
+    case "scala" => "net.sourceforge.pmd" %% "pmd-scala" % pmdVersion
+    case language => "net.sourceforge.pmd" % s"pmd-$language" % pmdVersion
+  }
   val specs2Version = "4.12.12"
   val specs2 = "org.specs2" %% "specs2-core" % specs2Version
 

--- a/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
+++ b/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
@@ -25,7 +25,7 @@ object Cpd extends DuplicationTool {
       Languages.Javascript,
       Languages.Go,
       Languages.Java,
-      Languages.SQL,
+      Languages.PLSQL,
       Languages.Python,
       Languages.Ruby,
       Languages.Scala,
@@ -104,7 +104,7 @@ object Cpd extends DuplicationTool {
       case Languages.Javascript        => cpdConfiguration(new EcmascriptLanguage, 40, options)
       case Languages.Go                => cpdConfiguration(new GoLanguage, 40, options)
       case Languages.Java              => cpdConfiguration(new JavaLanguage, 100, options)
-      case Languages.SQL               => cpdConfiguration(new PLSQLLanguage, 100, options)
+      case Languages.PLSQL             => cpdConfiguration(new PLSQLLanguage, 100, options)
       case Languages.Python            => cpdConfiguration(new PythonLanguage, 50, options)
       case Languages.Ruby              => cpdConfiguration(new RubyLanguage, 50, options)
       case Languages.Swift             => cpdConfiguration(new SwiftLanguage, 50, options)

--- a/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
+++ b/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
@@ -3,8 +3,9 @@ package com.codacy.duplication.pmd
 import _root_.java.io.{ByteArrayOutputStream, PrintStream}
 import _root_.java.nio.charset.StandardCharsets
 import _root_.java.nio.file.{Path, Paths}
+import _root_.java.util.Properties
 
-import better.files.File
+import better.files._
 import com.codacy.docker.api.duplication._
 import com.codacy.plugins.api.duplication.{DuplicationClone, DuplicationCloneFile, DuplicationTool}
 import com.codacy.plugins.api.languages.{Language, Languages}
@@ -48,7 +49,15 @@ object Cpd extends DuplicationTool {
     val directoryPath: Path = (File.currentWorkingDirectory / path.path).path
 
     val cpdResultsTry = resolveLanguages(language).map { languages =>
-      resolveConfigurations(languages, options).flatMap(runWithConfiguration(_, directoryPath))
+      languages.flatMap { language =>
+        val files = File(directoryPath)
+          .walk()
+          .filter(file => file.isRegularFile && language.extensions.contains(file.extension.getOrElse(file.name)))
+          .toSeq
+
+        val configuration = resolveConfiguration(language, options)
+        runWithConfiguration(configuration, directoryPath, files)
+      }
     }
 
     System.setErr(stdErr)
@@ -66,9 +75,11 @@ object Cpd extends DuplicationTool {
     }
   }
 
-  private def runWithConfiguration(config: CPDConfiguration, directory: Path): List[DuplicationClone] = {
+  private def runWithConfiguration(config: CPDConfiguration,
+                                   directory: Path,
+                                   files: Seq[File]): List[DuplicationClone] = {
     val cpd = new CPD(config)
-    cpd.addRecursively(directory.toFile)
+    cpd.add(files.map(_.toJava).asJava)
     cpd.go()
     cpd.getMatches.asScala.map(duplicationClone(_, directory)).toList
   }
@@ -86,28 +97,17 @@ object Cpd extends DuplicationTool {
     }
   }
 
-  private def resolveConfigurations(languages: List[Language],
-                                    options: Map[Options.Key, Options.Value]): List[CPDConfiguration] = {
-
-    languages.flatMap(resolveConfiguration(_, options))
-  }
-
-  private def resolveConfiguration(language: Language,
-                                   options: Map[Options.Key, Options.Value]): Option[CPDConfiguration] = {
+  private def resolveConfiguration(language: Language, options: Map[Options.Key, Options.Value]): CPDConfiguration = {
     language match {
-      case Languages.CSharp => Some(cpdConfiguration(new CsLanguage, 50, options))
-      case Languages.C | Languages.CPP =>
-        val language = new CPPLanguage()
-        // TODO: This workaround can be removed after 6.7.0
-        language.setProperties(System.getProperties)
-        Some(cpdConfiguration(language, 50, options))
-      case Languages.Javascript => Some(cpdConfiguration(new EcmascriptLanguage, 40, options))
-      case Languages.Go         => Some(cpdConfiguration(new GoLanguage, 40, options))
-      case Languages.Java       => Some(cpdConfiguration(new JavaLanguage, 100, options))
-      case Languages.SQL        => Some(cpdConfiguration(new PLSQLLanguage, 100, options))
-      case Languages.Python     => Some(cpdConfiguration(new PythonLanguage, 50, options))
-      case Languages.Ruby       => Some(cpdConfiguration(new RubyLanguage, 50, options))
-      case Languages.Swift      => Some(cpdConfiguration(new SwiftLanguage, 50, options))
+      case Languages.CSharp            => cpdConfiguration(new CsLanguage, 50, options)
+      case Languages.C | Languages.CPP => cpdConfiguration(new CPPLanguage(), 50, options)
+      case Languages.Javascript        => cpdConfiguration(new EcmascriptLanguage, 40, options)
+      case Languages.Go                => cpdConfiguration(new GoLanguage, 40, options)
+      case Languages.Java              => cpdConfiguration(new JavaLanguage, 100, options)
+      case Languages.SQL               => cpdConfiguration(new PLSQLLanguage, 100, options)
+      case Languages.Python            => cpdConfiguration(new PythonLanguage, 50, options)
+      case Languages.Ruby              => cpdConfiguration(new RubyLanguage, 50, options)
+      case Languages.Swift             => cpdConfiguration(new SwiftLanguage, 50, options)
       case Languages.Scala =>
         val cpdScala = new ScalaLanguage
         val scalaLanguage = new AbstractLanguage(
@@ -115,22 +115,35 @@ object Cpd extends DuplicationTool {
           cpdScala.getTerseName,
           com.codacy.duplication.pmd.ScalaTokenizer,
           cpdScala.getExtensions.asScala.toSeq: _*) {}
-        Some(cpdConfiguration(scalaLanguage, 50, options))
-      case _ => None
+        cpdConfiguration(scalaLanguage, 50, options)
+      case other =>
+        throw new Exception(s"$other Language not supported")
     }
   }
 
   private def cpdConfiguration(cpdLanguage: CPDLanguage,
                                defaultMinToken: Int,
                                options: Map[Options.Key, Options.Value]): CPDConfiguration = {
+    val ignoreLiterals = options.getValue(ignoreLiteralsKey, true)
+    val ignoreAnnotations = options.getValue(ignoreAnnotationsKey, true)
+    val ignoreUsings = options.getValue(ignoreUsingsKey, true)
+    val ignoreIdentifiers = options.getValue(ignoreIdentifiersKey, true)
+
+    cpdLanguage.setProperties(
+      languageProperties(
+        ignoreLiterals = ignoreLiterals,
+        ignoreIdentifiers = ignoreIdentifiers,
+        ignoreAnnotations = ignoreAnnotations,
+        ignoreUsings = ignoreUsings))
+
     val cfg = new CPDConfiguration()
     cfg.setLanguage(cpdLanguage)
-    cfg.setIgnoreAnnotations(options.getValue(ignoreAnnotationsKey, true))
+    cfg.setIgnoreAnnotations(ignoreAnnotations)
     cfg.setSkipLexicalErrors(options.getValue(skipLexicalErrorsKey, true))
     cfg.setMinimumTileSize(options.getValue(minimumTileSizeKey, defaultMinToken))
-    cfg.setIgnoreIdentifiers(options.getValue(ignoreIdentifiersKey, true))
-    cfg.setIgnoreLiterals(options.getValue(ignoreLiteralsKey, true))
-    cfg.setIgnoreUsings(options.getValue(ignoreUsingsKey, true))
+    cfg.setIgnoreIdentifiers(ignoreIdentifiers)
+    cfg.setIgnoreLiterals(ignoreLiterals)
+    cfg.setIgnoreUsings(ignoreUsings)
     cfg
   }
 
@@ -141,6 +154,26 @@ object Cpd extends DuplicationTool {
     }.to(List)
 
     DuplicationClone(m.getSourceCodeSlice, m.getTokenCount, m.getLineCount, files)
+  }
+
+  private def languageProperties(ignoreLiterals: Boolean,
+                                 ignoreIdentifiers: Boolean,
+                                 ignoreAnnotations: Boolean,
+                                 ignoreUsings: Boolean): Properties = {
+    val p = System.getProperties()
+    if (ignoreLiterals) {
+      p.setProperty(Tokenizer.IGNORE_LITERALS, "true")
+    }
+    if (ignoreIdentifiers) {
+      p.setProperty(Tokenizer.IGNORE_IDENTIFIERS, "true")
+    }
+    if (ignoreAnnotations) {
+      p.setProperty(Tokenizer.IGNORE_ANNOTATIONS, "true")
+    }
+    if (ignoreUsings) {
+      p.setProperty(Tokenizer.IGNORE_USINGS, "true")
+    }
+    p
   }
 
 }

--- a/src/test/scala/com/codacy/duplication/pmd/CpdSpec.scala
+++ b/src/test/scala/com/codacy/duplication/pmd/CpdSpec.scala
@@ -148,20 +148,15 @@ class CpdSpec extends Specification {
   }
 
   private def plsqlTest(): MatchResult[Try[List[DuplicationClone]]] = {
-    val clonesTry = executeDuplication(codePath, Some(Languages.SQL))
+    val clonesTry = executeDuplication(codePath, Some(Languages.PLSQL))
 
     clonesTry should beSuccessfulTry
 
     clonesTry must beLike {
       case Success(clones) =>
-        clones must haveLength(1)
+        clones must haveLength(5)
 
-        testClone(clones.head)(
-          codePath,
-          18,
-          125,
-          2,
-          List("plsql/pljson_parser.impl.sql", "plsql/pljson_parser.impl.1.sql"))
+        testClone(clones.head)(codePath, 17, 148, 2, List("plsql/pljson_parser.impl.sql"))
     }
   }
 


### PR DESCRIPTION
PMDCPD configuration expects that a language class has some properties
set when passing options. We were passing the options to the configuration
object via `.setIgnoreUsings(true)` but this is not enough because the
`CSLanguage` class reads this option from a `java.util.Properties` object
which needs to be populated again with the correct property for ignore-using
to be used.
Moveover, when the language was not explicitly passed, or when the tool
was run multiple times with different languages, the analysis was performed
on all the files with all the supported languages.
So a CSharp file was first analyzed with the CSharp analyzer that
(after the properties fix) doesn't report issues when the `--ignore-usings`
flag is enabled, then the same CSharp file was re-analysed as a Java file,
and since the Java analyzer doesn't recognize the using syntax, the tool
was reporting the `using` code as a clone.
What we do now is to split the files by language and run every file
with just its specific language analyzer.