### PR TITLE
feature: Skip analyzing big files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@10.2.2
+  codacy: codacy/base@11.2.0
   codacy_plugins_test: codacy/plugins-test@1.1.1
 
 jobs:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "1.6.1"
 style = IntelliJ
 project.excludeFilters = ["target/.*"]
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.12"
 
 lazy val codacyDuplictionPmdCpd = project
   .in(file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.1
+sbt.version = 1.9.7

--- a/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
+++ b/src/main/scala/com/codacy/duplication/pmd/Cpd.scala
@@ -16,6 +16,11 @@ import _root_.scala.util.{Failure, Success, Try}
 
 object Cpd extends DuplicationTool {
 
+  // This should ideally come from configuration so changing the config is automatically propagated here.
+  // For now we are hardcoding it here which is defined here:
+  // https://github.com/codacy/codacy-worker/blob/6f2bee63b1c42a19f05b7b73497da001740d9e14/conf/application.conf#L107
+  private val MaxFileSize = 150000
+
   private val allLanguages: List[Language] =
     List[Language](
       Languages.CSharp,
@@ -44,7 +49,11 @@ object Cpd extends DuplicationTool {
       languages.flatMap { language =>
         val files = File(directoryPath)
           .walk()
-          .filter(file => file.isRegularFile && language.extensions.contains(file.extension.getOrElse(file.name)))
+          .filter(
+            file =>
+              file.isRegularFile &&
+                language.extensions.contains(file.extension.getOrElse(file.name)) &&
+                file.size < MaxFileSize)
           .toSeq
 
         val configuration = resolveConfiguration(language, options)


### PR DESCRIPTION
- Bump Scala to `2.13.12`
- Bump Sbt to `1.9.7`
- Bump codacy/base orb to `11.2.0`